### PR TITLE
Allow passing more args to Puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ const Editor = require('@reactive-video/builder');
     output: 'my-video.mp4',
     concurrency: 3,
     // headless: false,
+    // extraPuppeteerArgs: ['--no-sandbox', '--disable-setuid-sandbox']
   });
 
   // Or start a live preview:

--- a/packages/builder/index.js
+++ b/packages/builder/index.js
@@ -67,6 +67,7 @@ function Editor({
     jpegQuality = 90,
     captureMethod = 'screencast',
     sleepTimeBeforeCapture = 0, // See https://github.com/mifi/reactive-video/issues/4
+    extraPuppeteerArgs = [],
 
     frameRenderTimeout = 30000,
 
@@ -165,6 +166,7 @@ function Editor({
           '--force-device-scale-factor=1',
           // '--start-maximized',
           // `--window-size=${width},${height}`,
+          ...extraPuppeteerArgs
         ],
         headless,
         // dumpio: true,


### PR DESCRIPTION
It makes possible to add `['--no-sandbox', '--disable-setuid-sandbox']` ([Setting Up Chrome Linux Sandbox](https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#setting-up-chrome-linux-sandbox)) for solving https://github.com/mifi/reactive-video/issues/7